### PR TITLE
Move udev rule install to debian postinst

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,12 +41,6 @@ install(DIRECTORY
   DESTINATION share/${PROJECT_NAME}/
 )
 
-install(FILES
-  81-vive.rules
-  DESTINATION /etc/udev/rules.d/
-  PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
-  COMPONENT "udev_rules")
-
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   # the following line skips the linter which checks for copyrights

--- a/debian/postinst
+++ b/debian/postinst
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+mkdir -p /etc/udev/rules.d
+
+cat << EOF > /etc/udev/rules.d/81-vive.rules
+
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="28de", ATTRS{idProduct}=="2101", TAG+="uaccess", TAG+="systemd", ENV{SYSTEMD_WANTS}="indoor_pos.service"
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="28de", ATTRS{idProduct}=="2300", TAG+="uaccess", TAG+="systemd", ENV{SYSTEMD_WANTS}="indoor_pos.service"
+
+SUBSYSTEM=="usb", ATTRS{idVendor}=="28de", ATTRS{idProduct}=="2101", MODE="0666", GROUP="plugdev"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="28de", ATTRS{idProduct}=="2300", MODE="0666", GROUP="plugdev"
+
+EOF
+
+chmod 644 /etc/udev/rules.d/81-vive.rules

--- a/debian/prerm
+++ b/debian/prerm
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+if [ -e /etc/udev/rules.d/81-vive.rules ]; then
+    rm /etc/udev/rules.d/81-vive.rules
+fi


### PR DESCRIPTION
Generate udev rule file in debian postinst script instead of define file install in package.xml to avoid permission issues in colcon build.