### PR TITLE
fix artifactory build info

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -13,13 +13,10 @@ jobs:
       matrix:
         ros2_distro: [foxy, galactic]
     steps:
-
       - name: Checkout indoor_pos
         uses: actions/checkout@v2
         with:
           path: indoor_pos
-
-      # Run docker build
       - name: Run indoor_pos docker build
         env:
           ROS: 1
@@ -31,40 +28,46 @@ jobs:
           pushd indoor_pos
           ./build.sh ../bin/
           popd
+      - name: Upload build
+        uses: actions/upload-artifact@v2
+        with:
+          name: indoor_pos
+          path: bin/*.deb
+          retention-days: 1
 
-      - name: Install jfrog CLI tool
+  artifactory:
+    runs-on: ubuntu-latest
+    needs: tii-deb-build
+    if: github.event_name == 'push'
+    steps:
+      - name: Download builds
+        uses: actions/download-artifact@v2
+        with:
+          name: indoor_pos
+          path: bin
+      - uses: jfrog/setup-jfrog-cli@v2
         env:
-          JFROG_CLI_URL: https://ssrc.jfrog.io/artifactory/ssrc-gen-public-remote-cache/tools/jfrog/jfrog-1.45.2.tar.gz
-        if: github.event_name == 'push'
-        run: |
-          set -exu
-          mkdir -p "$GITHUB_WORKSPACE/.jfrog/bin"
-          curl -L "$JFROG_CLI_URL" -o "$GITHUB_WORKSPACE/.jfrog/jfrog.tar.gz"
-          tar -C "$GITHUB_WORKSPACE/.jfrog/bin" -zxf "$GITHUB_WORKSPACE/.jfrog/jfrog.tar.gz"
-          echo "$GITHUB_WORKSPACE/.jfrog/bin" >> "$GITHUB_PATH"
-          echo "JFROG_CLI_HOME_DIR=$GITHUB_WORKSPACE/.jfrog" >> "$GITHUB_ENV"
-
+          JF_ARTIFACTORY_1: ${{ secrets.ARTIFACTORY_TOKEN }}
       - name: Upload to Artifactory
         env:
-          ARTIFACTORY_TOKEN: ${{ secrets.ARTIFACTORY_TOKEN }}
           ARTIFACTORY_REPO: debian-public-local
           DISTRIBUTION: focal
           COMPONENT: fog-sw
           ARCHITECTURE: amd64
           BUILD_NAME: indoor-pos
           CI: true
-        if: github.event_name == 'push'
         run: |
           set -exu
-          jfrog rt c import "$ARTIFACTORY_TOKEN"
           jfrog rt ping
-          pkg=$(find bin -name 'ros-${{ matrix.ros2_distro }}-indoor-pos*.deb')
-          jfrog rt u --deb "$DISTRIBUTION/$COMPONENT/$ARCHITECTURE" \
-                     --target-props COMMIT="$GITHUB_SHA" \
-                     --build-name "$BUILD_NAME" \
-                     --build-number "$GITHUB_SHA" \
-                     "$pkg" \
-                     "$ARTIFACTORY_REPO"
+          for pkg in bin/*.deb
+          do
+            jfrog rt u --deb "$DISTRIBUTION/$COMPONENT/$ARCHITECTURE" \
+                       --target-props COMMIT="$GITHUB_SHA" \
+                       --build-name "$BUILD_NAME" \
+                       --build-number "$GITHUB_SHA" \
+                       "$pkg" \
+                       "$ARTIFACTORY_REPO"
+          done
           jfrog rt build-publish "$BUILD_NAME" "$GITHUB_SHA"
           jfrog rt bpr "$BUILD_NAME" "$GITHUB_SHA" "$ARTIFACTORY_REPO" \
                        --status dev \


### PR DESCRIPTION
build-info gets corrupted, when build publish is executed multiple
times. Change jfrog cli usage to action based.